### PR TITLE
Fix shuttle weight calculation in exercise 060

### DIFF
--- a/exercises/060_floats.zig
+++ b/exercises/060_floats.zig
@@ -43,7 +43,7 @@ pub fn main() void {
     //
     // We'll convert this weight from pound to kilograms at a
     // conversion of 0.453592kg to the pound.
-    const shuttle_weight: f16 = 0.453592 * 4480e6;
+    const shuttle_weight: f16 = 0.453592 * 4480e3;
 
     // By default, float values are formatted in scientific
     // notation. Try experimenting with '{d}' and '{d:.3}' to see

--- a/patches/patches/060_floats.patch
+++ b/patches/patches/060_floats.patch
@@ -4,8 +4,8 @@
      //
      // We'll convert this weight from pound to kilograms at a
      // conversion of 0.453592kg to the pound.
--    const shuttle_weight: f16 = 0.453592 * 4480e6;
-+    const shuttle_weight: f32 = 0.453592 * 4.480e6;
- 
+-    const shuttle_weight: f16 = 0.453592 * 4480e3;
++    const shuttle_weight: f32 = 0.453592 * 4480e3;
+
      // By default, float values are formatted in scientific
      // notation. Try experimenting with '{d}' and '{d:.3}' to see


### PR DESCRIPTION
Fix the number format from 4480e6 to 4480e3 to match the actual weight